### PR TITLE
Uses Bundle utility

### DIFF
--- a/Sources/UberCore/Colors.swift
+++ b/Sources/UberCore/Colors.swift
@@ -35,13 +35,13 @@ public extension UIColor {
     
     static let uberButtonHighlightedDarkBackground: UIColor = UIColor(
         named: "UberButtonHighlightedDarkBackground",
-        in: .module,
+        in: .resource(for: UberButton.self),
         compatibleWith: nil
     ) ?? UIColor.darkText
     
     static let uberButtonHighlightedLightBackground: UIColor = UIColor(
         named: "UberButtonHighlightedLightBackground",
-        in: .module,
+        in: .resource(for: UberButton.self),
         compatibleWith: nil
     ) ?? UIColor.darkText
     

--- a/Sources/UberRides/RideRequestButton.swift
+++ b/Sources/UberRides/RideRequestButton.swift
@@ -302,7 +302,7 @@ public class RideRequestButton: UberButton {
     }
     
     private func image(name: String) -> UIImage? {
-        UIImage(named: name, in: Bundle.module, compatibleWith: nil)
+        UIImage(named: name, in: .resource(for: RideRequestButton.self), compatibleWith: nil)
     }
 }
 


### PR DESCRIPTION
Swift PM supports referencing bundles using Bundle.main. This breaks integration for anyone building manually or wrapping in a Cocoapods Podspec.
This change uses Bundle utilities in each framework that will select the correct bundle to load resources from. 