### PR TITLE
Adds a new public protocol to back UberAuth static methods

### DIFF
--- a/Sources/UberAuth/UberAuth.swift
+++ b/Sources/UberAuth/UberAuth.swift
@@ -28,6 +28,34 @@ import Foundation
 public typealias AuthCompletion = (Result<Client, UberAuthError>) -> ()
 
 /// @mockable
+public protocol UberAuthInterface {
+    
+    /// Executes a single login session using the provided context
+    ///
+    /// - Parameters:
+    ///   - context: An `AuthContext` instance providing all information needed to execute authentication
+    ///   - completion: A closure to be called upon completion
+    static func login(context: AuthContext, completion: @escaping AuthCompletion)
+    
+    
+    /// Clears any saved auth information from the keychain
+    /// If `currentAuthContext` exists, logs out using the stored auth context
+    /// Otherwise, attempts to delete the saved auth token directly using the internal TokenManager
+    static func logout()
+    
+    /// Attempts to extract auth information from the provided URL.
+    /// This method should be called from the implemeting application's openURL function.
+    ///
+    /// - Parameter url: The URL that was passed into the implementing app
+    /// - Returns: A boolean indicating if the URL was handled or not
+    static func handle(_ url: URL) -> Bool
+}
+
+
+///
+/// An internal protocol that translates the class -> instance methods for UberAuth
+///
+/// @mockable
 protocol AuthManaging {
     
     func login(context: AuthContext, completion: @escaping AuthCompletion)
@@ -40,7 +68,7 @@ protocol AuthManaging {
 }
 
 /// Public interface for the uber-auth-ios library
-public final class UberAuth: AuthManaging {
+public final class UberAuth: UberAuthInterface, AuthManaging {
     
     // MARK: Public
     

--- a/examples/UberSDK/UberSDKTests/Mocks/Mocks.swift
+++ b/examples/UberSDK/UberSDKTests/Mocks/Mocks.swift
@@ -242,6 +242,41 @@ public class AuthProvidingMock: AuthProviding {
     public var isLoggedIn: Bool = false { didSet { isLoggedInSetCallCount += 1 } }
 }
 
+public class UberAuthInterfaceMock: UberAuthInterface {
+    public init() { }
+
+
+    public static private(set) var loginCallCount = 0
+    public static var loginHandler: ((AuthContext, @escaping AuthCompletion) -> ())?
+    public static func login(context: AuthContext, completion: @escaping AuthCompletion)  {
+        loginCallCount += 1
+        if let loginHandler = loginHandler {
+            loginHandler(context, completion)
+        }
+        
+    }
+
+    public static private(set) var logoutCallCount = 0
+    public static var logoutHandler: (() -> ())?
+    public static func logout()  {
+        logoutCallCount += 1
+        if let logoutHandler = logoutHandler {
+            logoutHandler()
+        }
+        
+    }
+
+    public static private(set) var handleCallCount = 0
+    public static var handleHandler: ((URL) -> (Bool))?
+    public static func handle(_ url: URL) -> Bool {
+        handleCallCount += 1
+        if let handleHandler = handleHandler {
+            return handleHandler(url)
+        }
+        return false
+    }
+}
+
 class AuthManagingMock: AuthManaging {
     init() { }
     init(isLoggedIn: Bool = false) {


### PR DESCRIPTION
## Description
This PR adds and exposes a new protocol that includes the static methods on UberAuth. This will allow integrators to mock/test UberAuth in their own apps.

## Testing
* Manually built/ran sample app
* Manually generated mocks to ensure nothing broke